### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -24,7 +24,7 @@ jobs:
       #    pip install black
       #    black --check . || true
       - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: flake8 . --count --exclude=reprint.py --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --profile black . || true
       - run: pip install -r requirements.txt || true
       - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,20 +1,18 @@
-name: itinerant_tester
+name: lint_python
 on:
   pull_request:
   push:
   #  branches: [master]
 jobs:
-  itinerant_tester:
+  lint_python:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
-        repo: ["https://github.com/google/oss-fuzz", "https://github.com/cclauss/itinerant-tester"]
     runs-on: ${{ matrix.os }}
     steps:
-      # - uses: actions/checkout@v2
-      - run: git clone ${{ matrix.repo }}
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
@@ -27,6 +25,6 @@ jobs:
       #    black --check . || true
       - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: isort --profile black --recursive . || true
+      - run: isort --profile black . || true
       - run: pip install -r requirements.txt || true
       - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,32 @@
+name: itinerant_tester
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  itinerant_tester:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.9]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+        repo: ["https://github.com/google/oss-fuzz", "https://github.com/cclauss/itinerant-tester"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # - uses: actions/checkout@v2
+      - run: git clone ${{ matrix.repo }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install black codespell flake8 isort pytest
+      - run: black --check . || true
+      # - run: black --diff . || true
+      # - if: matrix.python-version >= 3.6
+      #  run: |
+      #    pip install black
+      #    black --check . || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --profile black --recursive . || true
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -23,7 +23,7 @@ jobs:
       #  run: |
       #    pip install black
       #    black --check . || true
-      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --exclude=reprint.py --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --profile black . || true
       - run: pip install -r requirements.txt || true

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Here's an example screenshot:
 
 ![](https://github.com/FIGLAB/ubicoustics/blob/master/media/example_liveprediction_detail.gif?raw=true)
 
-Prediction confidence values will be shown in real time. The system checks whether the highest confidence value exceeds a given threshold AND wether the audio levels are significant enough to warrant an event trigger (e.g., > -40dB). These parameters can be adjusted using the `PREDICTION_THRES` and `DBLEVEL_THRES` parameters:
+Prediction confidence values will be shown in real time. The system checks whether the highest confidence value exceeds a given threshold AND whether the audio levels are significant enough to warrant an event trigger (e.g., > -40dB). These parameters can be adjusted using the `PREDICTION_THRES` and `DBLEVEL_THRES` parameters:
 
 ```python
 PREDICTION_THRES = 0.8 # confidence

--- a/reprint.py
+++ b/reprint.py
@@ -316,7 +316,7 @@ class output:
     def __init__(self, output_type="list", initial_len=1, interval=0, force_single_line=False, no_warning=False, sort_key=lambda x:x[0]):
         self.sort_key = sort_key
         self.no_warning = no_warning
-        no_warning and print("All reprint warning diabled.")
+        no_warning and print("All reprint warning disabled.")
 
         global is_atty
         # reprint does not work in the IDLE terminal, and any other environment that can't get terminal_size
@@ -346,7 +346,7 @@ class output:
         global is_atty
         if not is_atty:
             if not self.no_warning:
-                print("Not in terminal, reprint now using normal build-in print function.")
+                print("Not in terminal, reprint now using normal built-in print function.")
 
         return self.warped_obj
 


### PR DESCRIPTION
Output: https://github.com/cclauss/ubicoustics/actions

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.